### PR TITLE
Expand URLs in Open menu, + goo.gl as a url shortening option

### DIFF
--- a/turpial/api/interfaces/service.py
+++ b/turpial/api/interfaces/service.py
@@ -56,10 +56,10 @@ class GenericService:
         self.log.debug('GET Request: %s' % url)
         return urllib2.urlopen(url, data).read()
         
-    def _json_request(self, url):
+    def _json_request(self, url, data=None):
         ''' Process a GET request and returns a json hash '''
         self.log.debug('JSON Request: %s' % url)
-        return json.loads(urllib2.urlopen(url).read())
+        return json.loads(urllib2.urlopen(url, data).read())
         
     def _quote_url(self, url):
         longurl = urllib2.quote(url)

--- a/turpial/api/interfaces/service.py
+++ b/turpial/api/interfaces/service.py
@@ -27,6 +27,10 @@ try:
 except ImportError:
     MIME_FLAG = False
 
+class HeadRequest(urllib2.Request):
+    def get_method(self):
+        return "HEAD"
+
 class GenericService:
     def __init__(self):
         self.log = logging.getLogger('Service')
@@ -50,7 +54,11 @@ class GenericService:
         _file.close()
         
         return filename
-        
+
+    @staticmethod
+    def _expand_url(url):
+        return urllib2.urlopen(HeadRequest(url)).geturl()
+
     def _get_request(self, url, data=None):
         ''' Process a GET request and returns a text plain response '''
         self.log.debug('GET Request: %s' % url)

--- a/turpial/api/services/shorturl/googl.py
+++ b/turpial/api/services/shorturl/googl.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+"""Interfaz para goo.gl en Turpial"""
+
+import traceback
+
+from turpial.api.interfaces.service import GenericService
+from turpial.api.interfaces.service import ServiceResponse
+
+class GooglURLShorter(GenericService):
+    def __init__(self):
+        GenericService.__init__(self)
+        self.url = "http://goo.gl/api/url"
+        
+    def do_service(self, longurl):
+        longurl = self._quote_url(longurl)
+        data = "url=%s" % longurl
+        try:
+            resp = self._json_request(self.url, data)
+            return ServiceResponse(resp['short_url'])
+        except Exception, error:
+            self.log.debug("Error: %s\n%s" % (error, traceback.print_exc()))
+            return ServiceResponse(err=True, err_msg=_('Problem shorting URL'))
+        

--- a/turpial/api/servicesapi.py
+++ b/turpial/api/servicesapi.py
@@ -22,6 +22,7 @@ from turpial.api.services.shorturl.supr import SuprURLShorter
 from turpial.api.services.shorturl.unu import UnuURLShorter
 from turpial.api.services.shorturl.zima import ZimaURLShorter
 from turpial.api.services.shorturl.ur1ca import Ur1caURLShorter
+from turpial.api.services.shorturl.googl import GooglURLShorter
 
 from turpial.api.services.uploadpic.imgly import ImglyPicUploader
 from turpial.api.services.uploadpic.tweetphoto import TweetPhotoPicUploader
@@ -41,6 +42,7 @@ URL_SERVICES = {
     "su.pr": SuprURLShorter(),
     "zi.ma": ZimaURLShorter(),
     "ur1.ca": Ur1caURLShorter(),
+    "goo.gl": GooglURLShorter(),
     #"sku.nu": ShortenObject("http://sku.nu?url=%s"),
 }
 

--- a/turpial/api/servicesapi.py
+++ b/turpial/api/servicesapi.py
@@ -86,6 +86,10 @@ class HTTPServices(threading.Thread):
         self.register({'cmd': 'short_url', 'service': service, 'url': url},
                       callback)
     
+    def expand_url(self, url, callback):
+        self.register({'cmd': 'expand_url', 'url': url},
+                      callback)
+
     def upload_pic(self, service, path, message, callback):
         self.register({'cmd': 'upload_pic', 'service': service, 'path': path,
                       'message': message}, callback)
@@ -136,6 +140,14 @@ class HTTPServices(threading.Thread):
                 resp = urlshorter.do_service(args['url'])
                 self.log.debug('URL Cortada: %s' % resp.response)
                 callback(resp)
+            elif args['cmd'] == 'expand_url':
+                self.log.debug('Expand URL: %s' % args['url'])
+                try:
+                    expanded = GenericService._expand_url(args['url'])
+                    callback(expanded)
+                except Exception, error:
+                    self.log.debug("Failed to expand url: %s" % error)
+                    callback(args['url'])
             elif args['cmd'] == 'upload_pic':
                 self.log.debug('Subiendo imagen [%s]: %s' % 
                                (args['service'], args['path']))

--- a/turpial/config.py
+++ b/turpial/config.py
@@ -50,6 +50,7 @@ DEFAULT_CFG = {
         'remember-login-info': 'off',
         'minimize-on-close': 'on',
         'num-tweets': '60',
+        'expand-urls': 'off',
     },
     'Window': {
         'single-win-size': '320,480',

--- a/turpial/main.py
+++ b/turpial/main.py
@@ -408,6 +408,9 @@ class Turpial:
     def short_url(self, text, callback):
         service = self.config.read('Services', 'shorten-url')
         self.httpserv.short_url(service, text, callback)
+
+    def expand_url(self, url, callback):
+        self.httpserv.expand_url(url, callback)
     
     def download_user_pic(self, user, pic_url, callback):
         self.httpserv.download_pic(user, pic_url, callback)

--- a/turpial/ui/base_ui.py
+++ b/turpial/ui/base_ui.py
@@ -205,6 +205,10 @@ class BaseGui:
         '''Short URL'''
         self.__controller.short_url(longurl, callback)
         
+    def request_expanded_url(self, url, callback):
+        '''Expand URL'''
+        self.__controller.expand_url(url, callback)
+
     def request_upload_pic(self, filename, message, callback):
         '''Upload a pic'''
         self.__controller.upload_pic(filename, message, callback)

--- a/turpial/ui/gtk/menu.py
+++ b/turpial/ui/gtk/menu.py
@@ -162,6 +162,10 @@ class Menu:
             umenu = gtk.MenuItem(url)
             umenu.connect('button-release-event', self.__open_url_with_event, u)
             open_menu.append(umenu)
+            if self.mainwin.read_config_value('General', 'expand-urls') == 'on':
+                def __update_umenu(text):
+                    umenu.child.set_text( text )
+                self.mainwin.request_expanded_url(u, __update_umenu)
         
         if len(total_urls) > 0 and len(total_tags) > 0: 
             open_menu.append(gtk.SeparatorMenuItem())

--- a/turpial/ui/gtk/menu.py
+++ b/turpial/ui/gtk/menu.py
@@ -164,7 +164,10 @@ class Menu:
             open_menu.append(umenu)
             if self.mainwin.read_config_value('General', 'expand-urls') == 'on':
                 def __update_umenu(text):
-                    umenu.child.set_text( text )
+                    try:
+                        umenu.child.set_text( text )
+                    except Exception, error:
+                        print error
                 self.mainwin.request_expanded_url(u, __update_umenu)
         
         if len(total_urls) > 0 and len(total_tags) > 0: 

--- a/turpial/ui/gtk/preferences.py
+++ b/turpial/ui/gtk/preferences.py
@@ -166,6 +166,7 @@ timeline, mentions and direct messages'), current)
         pf = True if self.current['profile-color'] == 'on' else False
         ws = True if self.current['workspace'] == 'wide' else False
         min = True if self.current['minimize-on-close'] == 'on' else False
+        exp_urls = True if self.current['expand-urls'] == 'on' else False
         
         self.home = TimeScroll(_('Column 1 (Left)'), h,
             callback=self.update_api_calls)
@@ -209,6 +210,14 @@ when close'))
         except:
             pass
         
+        self.expand_urls = gtk.CheckButton(_('Expand URLs'))
+        self.expand_urls.set_active(exp_urls)
+        try:
+            self.expand_urls.set_has_tooltip(True)
+            self.expand_urls.set_tooltip_text(_('Expand URLS in Open menu'))
+        except:
+            pass
+
         self.pack_start(self.home, False, False, 5)
         self.pack_start(self.replies, False, False, 5)
         self.pack_start(self.directs, False, False, 5)
@@ -217,6 +226,7 @@ when close'))
         self.pack_start(self.workspace, False, False, 2)
         self.pack_start(self.profile_colors, False, False, 2)
         self.pack_start(self.minimize, False, False, 2)
+        self.pack_start(self.expand_urls, False, False, 2)
         self.show_all()
         self.update_api_calls()
         
@@ -230,6 +240,7 @@ hour') % calls)
         ws = 'wide' if self.workspace.get_active() else 'single'
         min = 'on' if self.minimize.get_active() else 'off'
         pf = 'on' if self.profile_colors.get_active() else 'off'
+        exp_url = 'on' if self.expand_urls.get_active() else 'off'
         
         return {
             'home-update-interval': int(self.home.value),
@@ -239,6 +250,7 @@ hour') % calls)
             'profile-color': pf,
             'minimize-on-close': min,
             'num-tweets': int(self.tweets.value),
+            'expand-urls': exp_url,
         }
 
 class NotificationsTab(PreferencesTab):


### PR DESCRIPTION
Hi

Here are 2 commits that I hope you consider including.

The first one simply adds Goo.gl to the list of available url shorteners.

The second one adds an option to expand URLs that appear in the Open menu. If selected, a HEAD request is made to the url in question, and the url in the Open menu is changed to the url of the redirect destination. This is useful for people that want to see which site a link is going to before clicking said link.

Any concerns, please let me know.

cheers
Magnus
