### PR TITLE
pynotify errors / bit.ly update / j.mp support

### DIFF
--- a/turpial/api/services/shorturl/bitly.py
+++ b/turpial/api/services/shorturl/bitly.py
@@ -5,27 +5,25 @@
 # Author: Wil Alvarez (aka Satanas)
 # Abr 19, 2010
 
-import urllib2
 import traceback
 
 from turpial.api.interfaces.service import GenericService
 from turpial.api.interfaces.service import ServiceResponse
 
+LOGIN = 'login=turpial'
 APIKEY = 'apiKey=R_5a84eae6dd4158a0636358c4f9efdecc'
-VERSION = 'version=2.0.1'
-APP = 'login=turpial'
 
 class BitlyURLShorter(GenericService):
-    def __init__(self):
+    def __init__(self, domain='bit.ly'):
         GenericService.__init__(self)
-        self.base = "http://api.bit.ly/shorten?%s&%s&%s&longUrl=%s"
+        self.base = 'http://api.bitly.com/v3/shorten?domain=%s' % domain # shorten?%s&%s&%s&longUrl=%s&domain=" + domain
         
     def do_service(self, keyurl):
-        longurl = self._quote_url(keyurl)
-        req = self.base % (VERSION, APP, APIKEY, longurl)
+        longurl = 'longurl=%s' % self._quote_url(keyurl)
+        req = '%s&%s' % (self.base, '&'.join([LOGIN, APIKEY, longurl]))
         try:
             resp = self._json_request(req)
-            return ServiceResponse(resp['results'][keyurl]['shortUrl'])
+            return ServiceResponse(resp['data']['url'])
         except Exception, error:
             self.log.debug("Error: %s\n%s" % (error, traceback.print_exc()))
             return ServiceResponse(err=True, err_msg=_('Problem shorting URL'))

--- a/turpial/api/servicesapi.py
+++ b/turpial/api/servicesapi.py
@@ -37,6 +37,7 @@ URL_SERVICES = {
     "tinyurl.com": TinyurlURLShorter(),
     "tr.im": TrimURLShorter(),
     "bit.ly": BitlyURLShorter(),
+    "j.mp": BitlyURLShorter(domain='j.mp'),
     "smlk.es": SmlkesURLShorter(),
     "su.pr": SuprURLShorter(),
     "zi.ma": ZimaURLShorter(),

--- a/turpial/notification.py
+++ b/turpial/notification.py
@@ -12,6 +12,7 @@ log = logging.getLogger('Notify')
 
 try:
     import pynotify
+    from glib import GError
     NOTIFY = True
 except ImportError:
     log.debug("pynotify is not installed")
@@ -50,7 +51,12 @@ class Notification:
                     icon = os.path.realpath(iconpath)
                 icon = "file://%s" % icon
                 notification = pynotify.Notification(title, message, icon)
-                notification.show()
+                try:
+                    notification.show()
+                except GError:
+                    log.debug('Notification service not running')
+                    global NOTIFY
+                    NOTIFY = False
     
     def new_tweets(self, title, count, tobject, tweet, icon):
         self.popup('%s (%i %s)' % (title, count, tobject), tweet, icon)

--- a/turpial/ui/gtk/login.py
+++ b/turpial/ui/gtk/login.py
@@ -80,6 +80,7 @@ class LoginBox(gtk.VBox):
         
         self.pack_start(table, False, False, 2)
         
+        self.btn_oauth.grab_focus()
         self.btn_oauth.connect('clicked', self.signin)
         self.password.connect('activate', self.signin)
         self.rhandler = self.remember.connect("toggled", self.__toogle_remember)


### PR DESCRIPTION
If GTK stuff is installed but not running, the script is able to load pynotify but can't use notifications. Solution is to look for a glib.GError.
