### PR TITLE
License, authors and translators are now visible in about box

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ class build(_build):
 # TODO: Maybe find some better ways to do this
 # looking distutils's copy_tree method
 data_files=[
+    ('./', ['AUTHORS', 'TRANSLATORS']),
     ('share/pixmaps', ['turpial/data/pixmaps/turpial.png']),
     ('share/applications', ['turpial.desktop']),
     ('share/doc/turpial', ['doc/turpial.png',

--- a/turpial/ui/gtk/about.py
+++ b/turpial/ui/gtk/about.py
@@ -28,14 +28,14 @@ class About:
             license = lic.read()
             lic.close()
         except Exception, msg:
-            license = 'This script is free software; you can redistribute it'
-            'and\/or modify it under the\n\terms of the GNU General Public '
-            'License as published by the Free Software\n\Foundation; either '
-            'version 3 of the License, or (at your option) any later version.'
-            '\n\n\You should have received a copy of the GNU General Public '
-            'License along with\n\this script (see license); if not, write to '
-            'the Free Software\n\Foundation, Inc., 59 Temple Place, Suite 330, '
-            'Boston, MA  02111-1307  USA'
+            license =  'This script is free software; you can redistribute it '
+            license += 'and/or modify it under the\nterms of the GNU General Public '
+            license += 'License as published by the Free Software\nFoundation; either ' 
+            license += 'version 3 of the License, or (at your option) any later version.'
+            license += '\n\nYou should have received a copy of the GNU General Public '
+            license += 'License along with\nthis script (see license); if not, write to '
+            license += 'the Free Software\nFoundation, Inc., 59 Temple Place, Suite 330, '
+            license += 'Boston, MA  02111-1307  USA'
         about.set_license(license)
         authors = []
         try:


### PR DESCRIPTION
Hi all,

I noticed some issue in about box... I'm using ubuntu and after had installed Turpial, in the about box license, translators and authors were not shown ^^ this commit fixes this..

Regards

=.4.S.=
