### PR TITLE
Fixed duplicate statuses issue

### DIFF
--- a/turpial/data/layout/js/main.js
+++ b/turpial/data/layout/js/main.js
@@ -861,4 +861,9 @@ function remove_statuses(column_id, number) {
     });
 }
 
+function remove_duplicate(column_id, status_ids) {
+    for(i in status_ids)
+        $('#list-' + column_id + " .tweet." + status_ids[i]).remove()
+}
+
 jQuery(document).bind('keydown', 'Ctrl+n',function (evt){show_update_box(); return false; });

--- a/turpial/ui/gtk/main.py
+++ b/turpial/ui/gtk/main.py
@@ -995,6 +995,15 @@ class Main(Base, Singleton, gtk.Window):
             self.container.execute("stop_updating_column('" + column.id_ + "');")
             self.show_notice(arg.errmsg, 'error')
             return
+        
+        # Remove duplicate elements
+        if column.size != 0:
+            status_ids = []
+            for status in arg.items:
+                status_ids.append(status.id_)
+            self.container.execute("remove_duplicate('" + column.id_ + "', " + str(status_ids) + ");")
+
+        #Show new statuses
         page = self.htmlparser.statuses(arg.items)
         element = "#list-%s" % column.id_
         extra = "stop_updating_column('" + column.id_ + "');";


### PR DESCRIPTION
This patch allows to avoid any duplicate status :) for every new status it controls if it's just present in the column and delete it, showing it in the correct position according with the timeline :)
