### PR TITLE
Keep a list of bundled fonts in ui.base

### DIFF
--- a/turpial/ui/base.py
+++ b/turpial/ui/base.py
@@ -6,18 +6,8 @@
 # Oct 09, 2011
 
 import os
-import pdb
-import sys
 import time
-import base64
-import urllib
-import logging
-import webbrowser
-import subprocess
 
-from xml.sax.saxutils import unescape
-
-from turpial import VERSION
 from turpial.ui.lang import i18n
 from turpial.singleton import Singleton
 
@@ -25,6 +15,7 @@ from libturpial.common import OS_MAC
 from libturpial.common.tools import detect_os
 
 MIN_WINDOW_WIDTH = 250
+
 
 class Base(Singleton):
     ACTION_REPEAT = 'repeat'
@@ -38,9 +29,21 @@ class Base(Singleton):
 
         self.images_path = os.path.realpath(os.path.join(
             os.path.dirname(__file__), '..', 'data', 'pixmaps'))
-        self.fonts_path = os.path.realpath(os.path.join(
-            os.path.dirname(__file__), '..', 'data', 'fonts'))
+
+        self.fonts_path = os.path.realpath(
+            os.path.join(
+                os.path.dirname(__file__), '..', 'data', 'fonts'
+            )
+        )
+        # Keep a list of installed app fonts to ease registration
+        # in the toolkit side
+        self.fonts = [
+            os.path.join(self.fonts_path, f)
+            for f in os.listdir(self.fonts_path)
+        ]
+
         self.home_path = os.path.expanduser('~')
+
         if detect_os() == OS_MAC:
             self.shortcut_key = 'Cmd'
         else:

--- a/turpial/ui/qt/main.py
+++ b/turpial/ui/qt/main.py
@@ -57,14 +57,8 @@ class Main(Base, QWidget):
         Base.__init__(self)
         QWidget.__init__(self)
 
-        QFontDatabase.addApplicationFont(os.path.join(self.fonts_path, 'Ubuntu-L.ttf'))
-        QFontDatabase.addApplicationFont(os.path.join(self.fonts_path, 'TitilliumWeb-Bold.ttf'))
-        QFontDatabase.addApplicationFont(os.path.join(self.fonts_path, 'TitilliumWeb-Regular.ttf'))
-        QFontDatabase.addApplicationFont(os.path.join(self.fonts_path, 'Monda-Regular.ttf'))
-
-        database = QFontDatabase()
-        #for f in database.families():
-        #    print f
+        for font_path in self.fonts:
+            QFontDatabase.addApplicationFont(font_path)
 
         self.templates_path = os.path.realpath(os.path.join(
             os.path.dirname(__file__), 'templates'))


### PR DESCRIPTION
Keep a list of bundled fonts in ui.base to ease registration in the toolkits
