### PR TITLE
Wrong attribut name in qt/worker.py

### DIFF
--- a/turpial/ui/qt/worker.py
+++ b/turpial/ui/qt/worker.py
@@ -316,10 +316,10 @@ class CoreWorker(QThread):
     # FIXME: Remove this after implement this in libturpial
     def load_account(self, account_id, trigger_signal=True):
         if trigger_signal:
-            self.register(self.core.accman.load, (account_id),
+            self.register(self.core.account_manager.load, (account_id),
                 self.__after_load_account)
         else:
-            self.core.accman.load(account_id)
+            self.core.account_manager.load(account_id)
             self.__after_load_account()
 
     def delete_account(self, account_id):


### PR DESCRIPTION
Got the following traceback when trying to load an account:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/turpial/ui/qt/accounts.py", line 176, in __relogin_account
    self.base.load_account(account_id)
  File "/usr/lib/python2.7/site-packages/turpial/ui/qt/main.py", line 366, in load_account
    self.core.load_account(account_id)
  File "/usr/lib/python2.7/site-packages/turpial/ui/qt/worker.py", line 339, in load_account
    self.register(self.core.accman.load, (account_id),
AttributeError: Core instance has no attribute 'accman'

This commit fixes it.
