### PR TITLE
[bugfix] custom_browser is NoneType when not set

### DIFF
--- a/turpial/ui/base.py
+++ b/turpial/ui/base.py
@@ -60,61 +60,6 @@ class Base(Singleton):
         #self.unitylauncher.add_quicklist_button(self.main_quit, i18n.get('exit'), True)
         #self.unitylauncher.show_menu()
 
-    # TODO: Put this in util.py
-    def humanize_size(self, size):
-        if size == 0:
-            return '0 B'
-
-        kbsize = size / 1024
-        if kbsize > 0:
-            mbsize = kbsize / 1024
-            if mbsize > 0:
-                gbsize = mbsize / 1024
-                if gbsize > 0:
-                    return "%.2f GB" % (mbsize / 1024.0)
-                else:
-                    return "%.2f MB" % (kbsize / 1024.0)
-            else:
-                return "%.2f KB" % (size / 1024.0)
-        else:
-            return "%.2f B" % size
-
-    def humanize_timestamp(self, status_timestamp):
-        now = time.time()
-        # FIXME: Workaround to fix the timestamp
-        offset = time.timezone if (time.localtime().tm_isdst == 0) else time.altzone
-        seconds = now - status_timestamp + offset
-
-        minutes = seconds / 60.0
-        if minutes < 1.0:
-            timestamp = i18n.get('now')
-        else:
-            if minutes < 60.0:
-                timestamp = "%i m" % minutes
-            else:
-                hours = minutes / 60.0
-                if hours < 24.0:
-                    timestamp = "%i h" % hours
-                else:
-                    dt = time.localtime(status_timestamp)
-                    month = time.strftime(u'%b', dt)
-                    year = dt.tm_year
-
-                    if year == time.localtime(now).tm_year:
-                        timestamp = u"%i %s" % (dt.tm_mday, month)
-                    else:
-                        timestamp = u"%i %s %i" % (dt.tm_mday, month, year)
-        return timestamp
-
-    def humanize_time_intervals(self, interval):
-        if interval > 1:
-            unit = i18n.get('minutes')
-        else:
-            unit = i18n.get('minute')
-        return " ".join([str(interval), unit])
-
-    def get_shortcut_string(self, key):
-        return "+".join([self.shortcut_key, key])
 
     #================================================================
     # Common methods to all interfaces

--- a/turpial/ui/lang.py
+++ b/turpial/ui/lang.py
@@ -188,6 +188,7 @@ STRINGS = {
     'error_uploading_image': _("Error uploading image"),
     'new_tweet_updated': _("1 new tweet updated"),
     'new_tweets_updated': _("%s new tweets updated"),
+    'updated': _("%s updated"),
     'test': _("Test"),
     'open': _("Open"),
     'update_frecuency_tooltip': _("Set how often are updated the columns"),

--- a/turpial/ui/notification.py
+++ b/turpial/ui/notification.py
@@ -6,6 +6,7 @@ import os
 import logging
 
 from turpial.ui.lang import i18n
+from libturpial.common.tools import get_username_from
 
 NOTIFY = True
 
@@ -52,7 +53,7 @@ class OSNotificationSystem:
         else:
             message = i18n.get('new_tweet_updated')
 
-        title = " ".join([i18n.get('updated'), column.slug])
+        title = i18n.get('updated') % get_username_from(column.account_id)
         self.notify(title, message)
 
     def user_followed(self, username):

--- a/turpial/ui/qt/main.py
+++ b/turpial/ui/qt/main.py
@@ -20,6 +20,7 @@ from PyQt4.QtGui import (
 from PyQt4.QtCore import QTimer, pyqtSignal, QRect
 
 from turpial.ui.base import * #NOQA
+from turpial.ui.util import humanize_size
 from turpial.ui.sound import SoundSystem
 from turpial.ui.notification import OSNotificationSystem
 

--- a/turpial/ui/qt/preferences.py
+++ b/turpial/ui/qt/preferences.py
@@ -247,7 +247,7 @@ class BrowserPage(QWidget):
 
         self.setLayout(vbox)
 
-        if current_browser == '':
+        if current_browser == None:
             self.default_browser.set_value(True)
             self.command.setText('')
             self.__on_defaul_selected()

--- a/turpial/ui/qt/queue.py
+++ b/turpial/ui/qt/queue.py
@@ -20,6 +20,7 @@ from PyQt4.QtCore import QTimer
 from PyQt4.QtCore import QString
 
 from turpial.ui.lang import i18n
+from turpial.ui.util import humanize_time_intervals
 from turpial.ui.qt.widgets import Window
 
 from libturpial.common.tools import get_protocol_from, get_username_from
@@ -116,7 +117,7 @@ class QueueDialog(Window):
         else:
             est_time = 0
 
-        humanized_est_time = self.base.humanize_time_intervals(est_time)
+        humanized_est_time = humanize_time_intervals(est_time)
         next_message = ' '.join([i18n.get('next_message_should_be_posted_in'), humanized_est_time])
 
         if len(self.base.core.list_statuses_queue()) == 0:
@@ -167,8 +168,8 @@ class QueueDialog(Window):
             model.setItem(row, 1, QStandardItem(QString.fromUtf8(status.text)))
             row += 1
 
-        humanized_interval = self.base.humanize_time_intervals(self.base.core.get_queue_interval())
-        humanized_est_time = self.base.humanize_time_intervals(est_time)
+        humanized_interval = humanize_time_intervals(self.base.core.get_queue_interval())
+        humanized_est_time = humanize_time_intervals(est_time)
 
         warning = i18n.get('messages_will_be_send') % humanized_interval
         next_message = ' '.join([i18n.get('next_message_should_be_posted_in'), humanized_est_time])

--- a/turpial/ui/qt/updatebox.py
+++ b/turpial/ui/qt/updatebox.py
@@ -20,6 +20,7 @@ from PyQt4.QtCore import QTimer
 from PyQt4.QtCore import pyqtSignal
 
 from turpial.ui.lang import i18n
+from turpial.ui.util import get_shortcut_string
 from turpial.ui.qt.loader import BarLoadIndicator
 from turpial.ui.qt.widgets import ImageButton, ErrorLabel
 
@@ -49,9 +50,9 @@ class UpdateBox(QWidget):
         self.char_count.setFont(font)
 
         self.update_button = QPushButton(i18n.get('update'))
-        self.update_button.setToolTip(self.base.get_shortcut_string('Enter'))
+        self.update_button.setToolTip(get_shortcut_string('Enter'))
         self.queue_button = QPushButton(i18n.get('add_to_queue'))
-        self.queue_button.setToolTip(self.base.get_shortcut_string('P'))
+        self.queue_button.setToolTip(get_shortcut_string('P'))
 
         self.accounts_combo = QComboBox()
 

--- a/turpial/ui/qt/webview.py
+++ b/turpial/ui/qt/webview.py
@@ -110,7 +110,7 @@ class StatusesWebView(QWebView):
             # Highlight mentions
             for mention in status.entities['mentions']:
                 pretty_mention = "<a href='profile:%s'>%s</a>" % (mention.url, mention.display_text)
-                message = message.replace(mention.search_for, pretty_mention)
+                message = re.sub(mention.search_for, pretty_mention, message, flags=re.IGNORECASE)
 
         if status.repeated_by:
             repeated_by = "%s %s" % (i18n.get('retweeted_by'), status.repeated_by)

--- a/turpial/ui/qt/webview.py
+++ b/turpial/ui/qt/webview.py
@@ -15,6 +15,7 @@ from PyQt4.QtCore import Qt
 from PyQt4.QtCore import pyqtSignal
 
 from turpial.ui.lang import i18n
+from turpial.ui.util import humanize_timestamp
 
 class StatusesWebView(QWebView):
 
@@ -91,7 +92,7 @@ class StatusesWebView(QWebView):
         message = status.text
         message = message.replace('\n', '<br/>')
         message = message.replace('\'', '&apos;')
-        timestamp = self.base.humanize_timestamp(status.timestamp)
+        timestamp = humanize_timestamp(status.timestamp)
 
         if status.entities:
             # Highlight URLs
@@ -194,7 +195,7 @@ class StatusesWebView(QWebView):
 
     def sync_timestamps(self, statuses):
         for status in statuses:
-            new_timestamp = self.base.humanize_timestamp(status.timestamp)
+            new_timestamp = humanize_timestamp(status.timestamp)
             cmd = """updateTimestamp('%s', '%s')""" % (status.id_, new_timestamp)
             self.execute_javascript(cmd)
 

--- a/turpial/ui/util.py
+++ b/turpial/ui/util.py
@@ -54,3 +54,60 @@ def unescape_text(text):
     text = text.replace('\r\n', ' ')
     text = text.replace('\n', ' ')
     return text
+
+
+def humanize_size(self, size):
+    if size == 0:
+        return '0 B'
+
+    kbsize = size / 1024
+    if kbsize > 0:
+        mbsize = kbsize / 1024
+        if mbsize > 0:
+            gbsize = mbsize / 1024
+            if gbsize > 0:
+                return "%.2f GB" % (mbsize / 1024.0)
+            else:
+                return "%.2f MB" % (kbsize / 1024.0)
+        else:
+            return "%.2f KB" % (size / 1024.0)
+    else:
+        return "%.2f B" % size
+
+def humanize_timestamp(self, status_timestamp):
+	now = time.time()
+	# FIXME: Workaround to fix the timestamp
+	offset = time.timezone if (time.localtime().tm_isdst == 0) else time.altzone
+	seconds = now - status_timestamp + offset
+
+	minutes = seconds / 60.0
+	if minutes < 1.0:
+		timestamp = i18n.get('now')
+	else:
+		if minutes < 60.0:
+			timestamp = "%i m" % minutes
+		else:
+			hours = minutes / 60.0
+			if hours < 24.0:
+				timestamp = "%i h" % hours
+			else:
+				dt = time.localtime(status_timestamp)
+				month = time.strftime(u'%b', dt)
+				year = dt.tm_year
+
+				if year == time.localtime(now).tm_year:
+					timestamp = u"%i %s" % (dt.tm_mday, month)
+				else:
+					timestamp = u"%i %s %i" % (dt.tm_mday, month, year)
+	return timestamp
+
+def humanize_time_intervals(self, interval):
+	if interval > 1:
+		unit = i18n.get('minutes')
+	else:
+		unit = i18n.get('minute')
+	return " ".join([str(interval), unit])
+
+def get_shortcut_string(self, key):
+	return "+".join([self.shortcut_key, key])
+


### PR DESCRIPTION
Got the following traceback when opening the PreferenceDialog for the first time 
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/turpial/ui/qt/main.py", line 278, in show_preferences_dialog
    self.preferences_dialog = PreferencesDialog(self)
  File "/usr/lib/python2.7/site-packages/turpial/ui/qt/preferences.py", line 44, in **init**
    self.browser_page = BrowserPage(base)
  File "/usr/lib/python2.7/site-packages/turpial/ui/qt/preferences.py", line 256, in **init**
    self.command.setText(current_browser)
TypeError: QLineEdit.setText(QString): argument 1 has unexpected type 'NoneType'

The commit fixes the faulty type
