### PR TITLE
[bugfix] custom_browser is NoneType when not set

### DIFF
--- a/turpial/ui/qt/preferences.py
+++ b/turpial/ui/qt/preferences.py
@@ -247,7 +247,7 @@ class BrowserPage(QWidget):
 
         self.setLayout(vbox)
 
-        if current_browser == '':
+        if current_browser == None:
             self.default_browser.set_value(True)
             self.command.setText('')
             self.__on_defaul_selected()


### PR DESCRIPTION
Got the following traceback when opening the PreferenceDialog for the first time
Traceback (most recent call last):
File "/usr/lib/python2.7/site-packages/turpial/ui/qt/main.py", line 278, in show_preferences_dialog
self.preferences_dialog = PreferencesDialog(self)
File "/usr/lib/python2.7/site-packages/turpial/ui/qt/preferences.py", line 44, in init
self.browser_page = BrowserPage(base)
File "/usr/lib/python2.7/site-packages/turpial/ui/qt/preferences.py", line 256, in init
self.command.setText(current_browser)
TypeError: QLineEdit.setText(QString): argument 1 has unexpected type 'NoneType'

The commit fixes the faulty type
