### PR TITLE
Username as notification title

### DIFF
--- a/turpial/ui/lang.py
+++ b/turpial/ui/lang.py
@@ -188,6 +188,7 @@ STRINGS = {
     'error_uploading_image': _("Error uploading image"),
     'new_tweet_updated': _("1 new tweet updated"),
     'new_tweets_updated': _("%s new tweets updated"),
+    'updated': _("%s updated"),
     'test': _("Test"),
     'open': _("Open"),
     'update_frecuency_tooltip': _("Set how often are updated the columns"),

--- a/turpial/ui/notification.py
+++ b/turpial/ui/notification.py
@@ -6,6 +6,7 @@ import os
 import logging
 
 from turpial.ui.lang import i18n
+from libturpial.common.tools import get_username_from
 
 NOTIFY = True
 
@@ -52,7 +53,7 @@ class OSNotificationSystem:
         else:
             message = i18n.get('new_tweet_updated')
 
-        title = " ".join([i18n.get('updated'), column.slug])
+        title = i18n.get('updated') % get_username_from(column.account_id)
         self.notify(title, message)
 
     def user_followed(self, username):


### PR DESCRIPTION
[enh] Notifications of column update display the username the column belong to as title. It doesn't display the title of the column but I don't think it's a very relevant info.
It adds a string to translate; I don' t know how to handle this.

Fixes issue #234

Preview (in Gnome-Shell) :
![notif_turpial](https://f.cloud.github.com/assets/1036656/2368489/af02b6f4-a7ac-11e3-9895-6516f8db58d3.png)
