### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Turpial needs this packages to work properly:
  * ``setuptools`` (python2-distribute)
  * ``pkg-resources``
 
-Currently Turpial suports 3 different interfaces: Shell, Gtk and Qt. The shell 
+Currently Turpial supports 3 different interfaces: Shell, Gtk and Qt. The shell 
 interface needs no more dependencies to work, but if you are planning to run 
 Gtk or Qt you will need to install a couple of more dependencies:
 

--- a/turpial/ui/gtk/accounts.py
+++ b/turpial/ui/gtk/accounts.py
@@ -219,7 +219,7 @@ class AccountsDialog(Gtk.Window):
             # Delete account if wasn't configured properly
             iter_ = self.model.get_iter_first()
             # If this is the first account you try to add delete it, else loop
-            # throught the model and see which ones are registered but are not
+            # through the model and see which ones are registered but are not
             # in the model
             if iter_ is None:
                 try:

--- a/turpial/ui/gtk/profiles.py
+++ b/turpial/ui/gtk/profiles.py
@@ -115,7 +115,7 @@ class ProfileBox(Gtk.VBox):
         self.base = base
         self.avatar = Gtk.Image()
         self.avatar.set_margin_right(AVATAR_MARGIN)
-        # This resize is to avoid bad redimentioning on parent window
+        # This resize is to avoid bad redimensioning on parent window
         self.set_size_request(300, -1)
         avatar_box = Gtk.Alignment()
         avatar_box.add(self.avatar)


### PR DESCRIPTION
There are small typos in:
- README.rst
- turpial/ui/gtk/accounts.py
- turpial/ui/gtk/profiles.py

Fixes:
- Should read `through` rather than `throught`.
- Should read `supports` rather than `suports`.
- Should read `redimensioning` rather than `redimentioning`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md